### PR TITLE
Pending task/job returns html status 202 instead of 404

### DIFF
--- a/transcriptionservice/document/swagger.yaml
+++ b/transcriptionservice/document/swagger.yaml
@@ -64,15 +64,15 @@ paths:
             text/plain:
               schema:
                 type: string
-                default: This is a transcription
+                example: The transcription
             text/vtt:
               schema:
                 type: string
-                default: Return the transcription as VTT subtitles.
+                example: The transcription as VTT subtitles.
             text/srt:
               schema:
                 type: string
-                default: Return the transcription as SRT subtitles.
+                example: The transcription as SRT subtitles.
         201:
           description: Successfully created transcription job
           content:
@@ -123,15 +123,15 @@ paths:
             text/plain:
               schema:
                 type: string
-                default: This is a transcription
+                example: The transcription
             text/vtt:
               schema:
                 type: string
-                default: Return the transcription as VTT subtitles.
+                example: The transcription as VTT subtitles.
             text/srt:
               schema:
                 type: string
-                default: Return the transcription as SRT subtitles.
+                example: The transcription as SRT subtitles.
         201:
           description: Successfully created transcription job
           content:
@@ -173,25 +173,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/jobFinished'
         202:
-          description: Task is still processing. Return job progress
+          description: Task is pending or still processing. Returns job progress
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/jobInProgress'
-        400:
+        404:
+          description: jobid hasn't been found
+          content: 
+            application/json:
+              schema: 
+                $ref: '#/components/schemas/jobUnknown'
+        500:
           description: Task has failed
           content: 
             application/json:
               schema: 
                 $ref: '#/components/schemas/jobFailed'
-
-
-        404:
-          description: JobId hasn't been found
-          content: 
-            application/json:
-              schema: 
-                $ref: '#/components/schemas/jobUnknown'
   
   /results/{result_id}:
     get:
@@ -238,15 +236,15 @@ paths:
             text/plain:
               schema:
                 type: string
-                default: This is a transcription
+                example: The transcription
             text/vtt:
               schema:
                 type: string
-                default: Return the transcription as VTT subtitles.
+                example: The transcription as VTT subtitles.
             text/srt:
               schema:
                 type: string
-                default: Return the transcription as SRT subtitles.
+                example: The transcription as SRT subtitles.
         404:
           description: No ressource found for this id
 
@@ -391,14 +389,68 @@ components:
         steps:
           type: object
           properties:
+            preprocessing:
+              type: object
+              properties:
+                required:
+                  type: boolean
+                  enum: [true]
+                state:
+                  type: string
+                  enum: ["pending", "done", "started"]
+                  example: "done"
+                progress:
+                  type: number
+                  default: 1.0
+            diarization:
+              type: object
+              properties:
+                required:
+                  type: boolean
+                  default: true
+                state:
+                  type: string
+                  enum: ["pending", "done", "started"]
+                  example: "started"
+                progress:
+                  type: number
+                  example: 0.0
             transcription:
               type: object
               properties:
                 required:
                   type: boolean
+                  enum: [true]
                 state:
                   type: string
-                  default: "pending | started | done"
+                  enum: ["pending", "done", "started"]
+                  example: "started"
+                progress:
+                  type: number
+                  example: 0.250197289414994
+            punctuation:
+              type: object
+              properties:
+                required:
+                  type: boolean
+                  default: true
+                state:
+                  type: string
+                  enum: ["pending", "done", "started"]
+                  example: "pending"
+                progress:
+                  type: number
+                  example: 0.0
+            postprocessing:
+              type: object
+              properties:
+                required:
+                  type: boolean
+                  enum: [true]
+                state:
+                  type: string
+                  enum: ["pending", "done", "started"]
+                  example: "pending"
                 progress:
                   type: number
                   default: 0.0
@@ -407,16 +459,19 @@ components:
       properties:
         state:
           type: string
-          default: finished
-        ressource_id:
+          enum: ["done"]
+        result_id:
           type: string
-          default: "ressource_id to use on the /results/{ressource_id} route"
+          default: "552d2b53-e0cb-41c6-b5ed-a75a7fbde757 (hash to be used on the /results/{hash} route)"
     jobUnknown:
       type: object
       properties:
         state:
           type: string
-          default: "unknown"
+          default: "failed"
+        reason:
+          type: string
+          default: "Unknown jobid XXX"
     jobFailed:
       type: object
       properties:
@@ -425,7 +480,7 @@ components:
           default: "failed"
         reason:
           type: string
-          default: "The server encountered an error"
+          default: "An error message"
     transcriptionResult:
       type: object
       properties:


### PR DESCRIPTION
- Pending task/job returns 202 instead of 404 (reserved for unknown jobid).
   - There was an issue because celery does not distinguish (by default) between pending tasks and tasks that never existed (which deserve a 404).
   -  See discussion on https://stackoverflow.com/questions/9824172/find-out-whether-celery-task-exists
   - Note: I took the trick from this stackoverflow discussion. It looked to me much better than the "handcrafted" one that ChatGPT gave me (which consisted in keeping in memory a list with all the pending tasks).
- Always return a 500 in case of failure.
- Fix and improve swagger documentation
   - The main error was claiming 400 instead of 500 for errors (although only returning 400 for a very special unexpected error). And the bug on 404 status on pending jobs was not reported on the doc.

![Screenshot from 2023-09-20 11-10-24](https://github.com/linto-ai/linto-platform-transcription-service/assets/22522728/cbb59b18-f221-4362-a800-68ca3b053063)
