### PR TITLE
Ignore LANGUAGE=* when trying to convert numbers from letters into digits

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,6 @@
+# 1.2.12
+ - Do not fail when asking to convert numbers with env. variable LANGUAGE=*
+
 # 1.2.11
  - Improve heuristics to merge transcription and diarization results (for words in between two speaker turns)
 

--- a/transcriptionservice/server/formating/normalization.py
+++ b/transcriptionservice/server/formating/normalization.py
@@ -25,6 +25,9 @@ logger = logging.getLogger("__transcription-service__")
 
 
 def textToNum(text: str, language: str) -> str:
+    if language == "*":
+        logger.warning("Language not specified, not converting numbers to digits")
+        return text
     # Note: we could add symbols conversions as well (e.g. "euros" -> "€", "pour cent" -> "%", etc.)
     #       but this seems awkward and prone to downstream bugs
     return "\n".join([alpha2digit(elem, language[:2]) for elem in text.split("\n")])

--- a/transcriptionservice/server/formating/normalization.py
+++ b/transcriptionservice/server/formating/normalization.py
@@ -28,10 +28,22 @@ def textToNum(text: str, language: str) -> str:
     if language == "*":
         logger.warning("Language not specified, not converting numbers to digits")
         return text
+    if len(language) < 2:
+        raise ValueError(f"Invalid language code '{language}'")
+    lang = language[:2].lower()
     # Note: we could add symbols conversions as well (e.g. "euros" -> "€", "pour cent" -> "%", etc.)
     #       but this seems awkward and prone to downstream bugs
-    return "\n".join([alpha2digit(elem, language[:2]) for elem in text.split("\n")])
+    return "\n".join([_alpha2digit(elem, lang) for elem in text.split("\n")])
 
+def _alpha2digit(text: str, language: str) -> str:
+    try:
+        return alpha2digit(text, language)
+    except Exception as err:
+        text_small = text
+        if len(text) > 200:
+            text_small = text[:100] + "..." + text[-100:]
+        logger.error(f"Error converting '{text_small}' to digits: {err}")
+        raise RuntimeError(f"Error converting '{text}' to digits with {language=}") from err
 
 def cleanText(text: str, language: str, user_sub: list) -> str:
 


### PR DESCRIPTION
This fixes this failure :
```
18/11/2024 14:33:09 __transcription-service__ DEBUG: Create trancription task with id c061af1b-dca1-4d38-aedf-e66139ead528
18/11/2024 14:33:23 __transcription-service__ DEBUG: Returning result fo result_id cc819ce2-6ed3-4657-aecc-5e65c9dbbfc2
18/11/2024 14:33:23 __services_manager__ ERROR: Exception on /results/cc819ce2-6ed3-4657-aecc-5e65c9dbbfc2 [GET]
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/flask/app.py", line 1473, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.10/site-packages/flask/app.py", line 882, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.10/site-packages/flask/app.py", line 880, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.10/site-packages/flask/app.py", line 865, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
  File "/usr/src/app/transcriptionservice/server/ingress.py", line 120, in results
    formatResult(
  File "/usr/src/app/transcriptionservice/server/formating/formatresult.py", line 41, in formatResult
    seg["segment"] = fulltext_cleaner(seg["segment"])
  File "/usr/src/app/transcriptionservice/server/formating/formatresult.py", line 35, in <lambda>
    fulltext_cleaner = lambda text: textToNum(cleanText(text, language, user_sub), language)
  File "/usr/src/app/transcriptionservice/server/formating/normalization.py", line 30, in textToNum
    return "\n".join([alpha2digit(elem, language[:2]) for elem in text.split("\n")])
  File "/usr/src/app/transcriptionservice/server/formating/normalization.py", line 30, in <listcomp>
    return "\n".join([alpha2digit(elem, language[:2]) for elem in text.split("\n")])
  File "/usr/local/lib/python3.10/site-packages/text_to_num/transforms.py", line 109, in alpha2digit
    raise Exception("Language not supported")
Exception: Language not supported
18/11/2024 14:33:23 __transcription-service__ ERROR: 500 Internal Server Error: The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.
```
